### PR TITLE
Execution record

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.logdyn</groupId>
     <artifactId>re-agent</artifactId>
-    <version>1.0</version>
+    <version>1.2-SNAPSHOT</version>
 
     <name>com.logdyn:re-agent</name>
     <description>A Java command delegation library, providing undo/redo functionality</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.logdyn</groupId>
     <artifactId>re-agent</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.2</version>
 
     <name>com.logdyn:re-agent</name>
     <description>A Java command delegation library, providing undo/redo functionality</description>

--- a/src/main/java/com/logdyn/ExecutionRecord.java
+++ b/src/main/java/com/logdyn/ExecutionRecord.java
@@ -2,7 +2,7 @@ package com.logdyn;
 
 import java.util.Comparator;
 
-class ExecutionRecord implements Comparable<ExecutionRecord>{
+public class ExecutionRecord implements Comparable<ExecutionRecord>{
     private Command command;
     private long timestamp;
     private Operation operation;


### PR DESCRIPTION
Bumped version to 1.2 (the 1.2-SNAPSHOT is available https://oss.sonatype.org/content/repositories/snapshots/com/logdyn/re-agent/)

Made execution record public so that it can be used to get the last command details properly when using commandDelegator.getLastExecutionRecord.

Otherwise in following code, `record` would be unavailable 

`commandDelegator.getLatestExecutionRecord().ifPresent(record -> {
                statusLabel.setText(String.format("%s %s", record.getOperation(), 
                record.getCommand().getName()));
});`
